### PR TITLE
Fixed `getMany` response

### DIFF
--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -98,7 +98,7 @@ export default (apiUrl: string, httpClient = fetchUtils.fetchJson): DataProvider
 
     const url = `${apiUrl}/${resource}?${query}`;
 
-    return httpClient(url).then(({ json }) => ({ data: json }));
+    return httpClient(url).then(({ json }) => ({ data: json.data }));
   },
 
   getManyReference: (resource, params) => {


### PR DESCRIPTION
For now getMany returns response which looks like
```
{data: {data: [items]}}
```
This change fixes this to correct `{data: [items]}` response