### PR TITLE
Set filter conditional to equals for UUID strings

### DIFF
--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -33,7 +33,7 @@ const composeFilter = (paramsFilter: any): QueryFilter[] => {
   const flatFilter = fetchUtils.flattenObject(paramsFilter);
   return Object.keys(flatFilter).map((key) => {
     const splitKey = key.split('||');
-    const uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/gi;
 
     let field = splitKey[0];
     let ops = splitKey[1];

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -33,11 +33,12 @@ const composeFilter = (paramsFilter: any): QueryFilter[] => {
   const flatFilter = fetchUtils.flattenObject(paramsFilter);
   return Object.keys(flatFilter).map((key) => {
     const splitKey = key.split('||');
+    const uuidRegex = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/gi;
 
     let field = splitKey[0];
     let ops = splitKey[1];
     if (!ops) {
-      if (typeof flatFilter[key] === 'boolean' || typeof flatFilter[key] === 'number' || (typeof flatFilter[key] === 'string' && flatFilter[key].match(/^\d+$/))) {
+      if (typeof flatFilter[key] === 'boolean' || typeof flatFilter[key] === 'number' || (typeof flatFilter[key] === 'string' && (flatFilter[key].match(/^\d+$/)) || flatFilter[key].match(uuidRegex))) {
         ops = CondOperator.EQUALS;
       } else {
         ops = CondOperator.CONTAINS;


### PR DESCRIPTION
The existing data provider logic makes the conditional for all non-numeric string $cont. This results in a failure for any value that is UUID when using a Postgres data as Postgres doesn't support LIKE `%${UUID}%`. 

I've added additional logic to make the conditional $eq for all string that matches regex for a UUID.