### PR TITLE
Feature: inline filter operator

### DIFF
--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -32,7 +32,7 @@ const countDiff = (o1: Record<string, any>, o2: Record<string, any>): Record<str
 const composeFilter = (paramsFilter: any): QueryFilter[] => {
   const flatFilter = fetchUtils.flattenObject(paramsFilter);
   return Object.keys(flatFilter).map((key) => {
-    const splitKey = key.split('||');
+    const splitKey = key.split(/\|\||:/)
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/gi;
 
     let field = splitKey[0];

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -1,5 +1,5 @@
 import { CondOperator, QueryFilter, QuerySort, RequestQueryBuilder } from '@nestjsx/crud-request';
-import omitBy from 'lodash.omitby';
+import omitBy from 'lodash.omitBy';
 import { DataProvider, fetchUtils } from 'ra-core';
 import { stringify } from 'query-string';
 

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -41,7 +41,7 @@ const composeFilter = (paramsFilter: any): QueryFilter[] => {
       if (typeof flatFilter[key] === 'boolean' || typeof flatFilter[key] === 'number' || (typeof flatFilter[key] === 'string' && (flatFilter[key].match(/^\d+$/)) || flatFilter[key].match(uuidRegex))) {
         ops = CondOperator.EQUALS;
       } else {
-        ops = CondOperator.CONTAINS;
+        ops = CondOperator.CONTAINS_LOW;
       }
     }
 


### PR DESCRIPTION
The PR makes 2 changes:

1. change the default operator to `$contL` (case insensitive contains)
2. allow the use of a semi-colon to insert a custom operator, as in: `<SearchInput source='name:$cont' />`

The use of a semi-colon is necessary because the use of double-pipes (as suggested in #26) was preventing the field from working properly in latest version of React-Admin (v4).

Note: since there is no tests and I”m new to React-Admin data provider, I don’t know if these changes can have side-effects I haven’t foreseen.